### PR TITLE
refactor: remove `@babel/generator` and simplify codegen for script setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,11 @@
     "vue": "^3.5.13"
   },
   "dependencies": {
-    "@babel/generator": "^7.27.0",
     "@babel/parser": "^7.27.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "4.11.0",
     "@babel/types": "^7.27.0",
-    "@types/babel__generator": "^7.27.0",
     "@types/node": "^22.14.0",
     "@vitest/coverage-v8": "3.1.1",
     "@vue/compiler-dom": "^3.5.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
 
   .:
     dependencies:
-      '@babel/generator':
-        specifier: ^7.27.0
-        version: 7.27.0
       '@babel/parser':
         specifier: ^7.27.0
         version: 7.27.0
@@ -22,9 +19,6 @@ importers:
         specifier: 4.11.0
         version: 4.11.0(@typescript-eslint/utils@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.2))(@vue/compiler-sfc@3.5.13)(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.14.0)(sass@1.86.3))
       '@babel/types':
-        specifier: ^7.27.0
-        version: 7.27.0
-      '@types/babel__generator':
         specifier: ^7.27.0
         version: 7.27.0
       '@types/node':
@@ -923,9 +917,6 @@ packages:
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -3507,6 +3498,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
+    optional: true
 
   '@babel/helper-string-parser@7.25.9': {}
 
@@ -4077,10 +4069,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.27.0
 
   '@types/debug@4.1.12':
     dependencies:

--- a/src/utils/script-setup.ts
+++ b/src/utils/script-setup.ts
@@ -219,7 +219,7 @@ function processDefineModel(node: Expression, context: Context): string | undefi
 
   const codegenType = model.length === 1 ? model[0] : `[${model.join(',')}]`
   const codegenExtra = modelRuntimeDecl ? `...${context.ctx.getString(modelRuntimeDecl)}` : ''
-  codegenArgs.push(`{ ${[`type: ${codegenType}`, codegenExtra].filter(s => !!s).join(',')} }`)
+  codegenArgs.push(`{ ${[`type: ${codegenType}`, codegenExtra].filter(s => !!s).join(', ')} }`)
 
   return `${DEFINE_MODEL}(${codegenArgs.join(', ')})`
 }

--- a/test/mkdist.test.ts
+++ b/test/mkdist.test.ts
@@ -18,10 +18,7 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       defineProps({
-        msg: {
-          type: String,
-          required: true
-        }
+        msg: { type: String, required: true }
       });
       </script>
       "
@@ -33,10 +30,7 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       const props = defineProps({
-        msg: {
-          type: String,
-          required: true
-        }
+        msg: { type: String, required: true }
       });
       </script>
       "
@@ -48,10 +42,7 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       const { msg } = defineProps({
-        msg: {
-          type: String,
-          required: true
-        }
+        msg: { type: String, required: true }
       });
       </script>
       "
@@ -63,10 +54,7 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       const { msg = "hello" } = defineProps({
-        msg: {
-          type: String,
-          required: false
-        }
+        msg: { type: String, required: false }
       });
       </script>
       "
@@ -81,11 +69,7 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       const props = defineProps({
-        msg: {
-          type: String,
-          required: false,
-          default: "hi"
-        }
+        msg: { type: String, required: false, default: "hi" }
       });
       </script>
       "
@@ -97,11 +81,7 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       defineProps({
-        msg: {
-          type: String,
-          required: false,
-          default: "hi"
-        }
+        msg: { type: String, required: false, default: "hi" }
       });
       </script>
       "
@@ -168,9 +148,7 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      const model = defineModel({
-        "type": String
-      });
+      const model = defineModel({ type: String });
       </script>
       "
     `)
@@ -178,9 +156,7 @@ describe('transform typescript script setup', () => {
       await fixture(`<script setup lang="ts">defineModel<string>()</script>`),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel({
-        "type": String
-      });
+      defineModel({ type: String });
       </script>
       "
     `)
@@ -190,9 +166,7 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel("msg", {
-        "type": String
-      });
+      defineModel("msg", { type: String });
       </script>
       "
     `)
@@ -202,12 +176,7 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel({
-        "type": String,
-        ...{
-          required: true
-        }
-      });
+      defineModel({ type: String, ...{ required: true } });
       </script>
       "
     `)
@@ -217,12 +186,7 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel("msg", {
-        "type": String,
-        ...{
-          required: true
-        }
-      });
+      defineModel("msg", { type: String, ...{ required: true } });
       </script>
       "
     `)

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -180,7 +180,7 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel({ type: String,...{ required: true } })
+      defineModel({ type: String, ...{ required: true } })
       </script>"
     `)
     expect(
@@ -189,7 +189,7 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel("msg", { type: String,...{ required: true } })
+      defineModel("msg", { type: String, ...{ required: true } })
       </script>"
     `)
   })

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -11,11 +11,8 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       defineProps({
-        msg: {
-          type: String,
-          required: true
-        }
-      })
+          msg: { type: String, required: true }
+        })
       </script>"
     `)
     expect(
@@ -25,11 +22,8 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       const props = defineProps({
-        msg: {
-          type: String,
-          required: true
-        }
-      })
+          msg: { type: String, required: true }
+        })
       </script>"
     `)
     expect(
@@ -39,11 +33,8 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       const { msg } = defineProps({
-        msg: {
-          type: String,
-          required: true
-        }
-      })
+          msg: { type: String, required: true }
+        })
       </script>"
     `)
     expect(
@@ -53,11 +44,8 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       const { msg = 'hello' } = defineProps({
-        msg: {
-          type: String,
-          required: false
-        }
-      })
+          msg: { type: String, required: false }
+        })
       </script>"
     `)
   })
@@ -80,11 +68,8 @@ describe('transform typescript script setup', () => {
                 locale?: Array<T>
               }
               const props = defineProps({
-        locale: {
-          type: Array,
-          required: false
-        }
-      })
+          locale: { type: Array, required: false }
+        })
               
       </script>"
     `)
@@ -98,12 +83,8 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       const props = defineProps({
-        msg: {
-          type: String,
-          required: false,
-          default: 'hi'
-        }
-      })
+          msg: { type: String, required: false, default: 'hi' }
+        })
       </script>"
     `)
     expect(
@@ -113,12 +94,8 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       defineProps({
-        msg: {
-          type: String,
-          required: false,
-          default: 'hi'
-        }
-      })
+          msg: { type: String, required: false, default: 'hi' }
+        })
       </script>"
     `)
   })
@@ -178,18 +155,14 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      const model = defineModel({
-        "type": String
-      })
+      const model = defineModel({ type: String })
       </script>"
     `)
     expect(
       await fixture(`<script setup lang="ts">defineModel<string>()</script>`),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel({
-        "type": String
-      })
+      defineModel({ type: String })
       </script>"
     `)
     expect(
@@ -198,9 +171,7 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel('msg', {
-        "type": String
-      })
+      defineModel("msg", { type: String })
       </script>"
     `)
     expect(
@@ -209,12 +180,7 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel({
-        "type": String,
-        ...{
-          required: true
-        }
-      })
+      defineModel({ type: String,...{ required: true } })
       </script>"
     `)
     expect(
@@ -223,12 +189,7 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel('msg', {
-        "type": String,
-        ...{
-          required: true
-        }
-      })
+      defineModel("msg", { type: String,...{ required: true } })
       </script>"
     `)
   })


### PR DESCRIPTION
When Vue compiles sfc, it does not translate any code from ast at all, but replaces it by splicing parameters after analyzing from ast.

So I thought we could also do this, then prune our dependencies down to only one.

I think the only difference of output is the format, but they all will transform by esbuild so never mind.