### PR TITLE
fix: enable `verbatimModuleSyntax` for script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:types": "tsc --noEmit"
   },
   "peerDependencies": {
-    "esbuild": "0.25.2",
+    "esbuild": "^0.25.2",
     "vue": "^3.5.13"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -44,13 +44,7 @@
     "test:types": "tsc --noEmit"
   },
   "peerDependencies": {
-    "esbuild": "^0.25.2",
     "vue": "^3.5.13"
-  },
-  "peerDependenciesMeta": {
-    "esbuild": {
-      "optional": true
-    }
   },
   "dependencies": {
     "@babel/parser": "^7.27.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=6.9.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "unbuild",
@@ -44,11 +44,11 @@
     "test:types": "tsc --noEmit"
   },
   "peerDependencies": {
+    "esbuild": "*",
     "vue": "^3.5.13"
   },
   "dependencies": {
-    "@babel/parser": "^7.27.0",
-    "esbuild": "0.25.2"
+    "@babel/parser": "^7.27.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "4.11.0",
@@ -58,6 +58,7 @@
     "@vue/compiler-dom": "3.5.13",
     "bumpp": "10.1.0",
     "changelogithub": "13.13.0",
+    "esbuild": "0.25.2",
     "eslint": "9.24.0",
     "exsolve": "1.0.4",
     "installed-check": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "vue": "^3.5.13"
   },
   "dependencies": {
-    "@babel/parser": "^7.27.0"
+    "@babel/parser": "^7.27.0",
+    "esbuild": "0.25.2"
   },
   "devDependencies": {
     "@antfu/eslint-config": "4.11.0",
@@ -57,7 +58,6 @@
     "@vue/compiler-dom": "3.5.13",
     "bumpp": "10.1.0",
     "changelogithub": "13.13.0",
-    "esbuild": "0.25.2",
     "eslint": "9.24.0",
     "exsolve": "1.0.4",
     "installed-check": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,13 @@
     "test:types": "tsc --noEmit"
   },
   "peerDependencies": {
+    "esbuild": "0.25.2",
     "vue": "^3.5.13"
+  },
+  "peerDependenciesMeta": {
+    "esbuild": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/parser": "^7.27.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@babel/parser':
         specifier: ^7.27.0
         version: 7.27.0
-      esbuild:
-        specifier: 0.25.2
-        version: 0.25.2
     devDependencies:
       '@antfu/eslint-config':
         specifier: 4.11.0
@@ -39,6 +36,9 @@ importers:
       changelogithub:
         specifier: 13.13.0
         version: 13.13.0(magicast@0.3.5)
+      esbuild:
+        specifier: 0.25.2
+        version: 0.25.2
       eslint:
         specifier: 9.24.0
         version: 9.24.0(jiti@2.4.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@babel/parser':
         specifier: ^7.27.0
         version: 7.27.0
+      esbuild:
+        specifier: 0.25.2
+        version: 0.25.2
     devDependencies:
       '@antfu/eslint-config':
         specifier: 4.11.0
@@ -36,9 +39,6 @@ importers:
       changelogithub:
         specifier: 13.13.0
         version: 13.13.0(magicast@0.3.5)
-      esbuild:
-        specifier: 0.25.2
-        version: 0.25.2
       eslint:
         specifier: 9.24.0
         version: 9.24.0(jiti@2.4.2)

--- a/src/mkdist.ts
+++ b/src/mkdist.ts
@@ -1,5 +1,6 @@
 import type { SFCBlock, SFCTemplateBlock } from 'vue/compiler-sfc'
 import type { InputFile, Loader, LoaderContext, LoaderResult, OutputFile } from './types/mkdist'
+import { transform } from 'esbuild'
 import { preTranspileScriptSetup, transpileVueTemplate } from './index'
 
 interface DefineVueLoaderOptions {
@@ -222,7 +223,6 @@ const scriptLoader: VueBlockLoader = async (block, { options }) => {
     return
   }
 
-  const { transform } = await esbuild()
   const { code: result } = await transform(block.content, {
     ...options.esbuild,
     loader: 'ts',
@@ -243,14 +243,6 @@ export const vueLoader = defineVueLoader({
     style: styleLoader,
   },
 })
-
-let esbuildCache: typeof import('esbuild')
-async function esbuild() {
-  if (!esbuildCache) {
-    esbuildCache = await import('esbuild')
-  }
-  return esbuildCache
-}
 
 function cleanupBreakLine(str: string): string {
   return str.replaceAll(/(\n\n)\n+/g, '\n\n').replace(/^\s*\n|\n\s*$/g, '')

--- a/test/mkdist.test.ts
+++ b/test/mkdist.test.ts
@@ -192,6 +192,30 @@ describe('transform typescript script setup', () => {
     `)
   })
 
+  it('do not tree-shake', async () => {
+    expect(
+      await fixture(
+        `<template>
+          <div :data-test="toValue('hello')" />
+        </template>
+        <script setup lang="ts">
+        import { toValue, type Ref } from 'vue'
+        const msg = 1
+        </script>`,
+      ),
+    ).toMatchInlineSnapshot(`
+      "<template>
+                <div :data-test="toValue('hello')" />
+      </template>
+
+      <script setup>
+      import { toValue } from "vue";
+      const msg = 1;
+      </script>
+      "
+    `)
+  })
+
   async function fixture(src: string): Promise<string> {
     await rm(tmpDir, { force: true, recursive: true })
     await mkdir(join(tmpDir, 'src'), { recursive: true })


### PR DESCRIPTION
resolve #9

This is one of the ways to solve the problem, maybe not the best.

idk why knip complains, maybe we don't need to specify esbuild as peer