### PR TITLE
fix: keep same behavior with vue in handling `Unknown` type on `defineModel`

### DIFF
--- a/src/utils/script-setup.ts
+++ b/src/utils/script-setup.ts
@@ -171,7 +171,7 @@ function processDefineModel(node: Expression, context: Context): string | undefi
     return
   }
 
-  const model = context.utils.inferRuntimeType(context.ctx, modelTypeDecl)
+  const model = context.utils.inferRuntimeType(context.ctx, modelTypeDecl).filter(i => i !== 'Unknown')
   if (!model || model.length === 0 || model[0] === 'Unknown') {
     return
   }
@@ -217,7 +217,7 @@ function processDefineModel(node: Expression, context: Context): string | undefi
     codegenArgs.push(`"${modelNameDecl.value}"`)
   }
 
-  const codegenType = model.length === 1 ? model[0] : `[${model.join(',')}]`
+  const codegenType = model.length === 1 ? model[0] : `[${model.join(', ')}]`
   const codegenExtra = modelRuntimeDecl ? `...${context.ctx.getString(modelRuntimeDecl)}` : ''
   codegenArgs.push(`{ ${[`type: ${codegenType}`, codegenExtra].filter(s => !!s).join(', ')} }`)
 

--- a/src/utils/script-setup.ts
+++ b/src/utils/script-setup.ts
@@ -219,12 +219,6 @@ function processDefineModel(node: Expression, context: Context): string | undefi
     })
   }
 
-  node.typeArguments = undefined
-  node.typeParameters = undefined
-  node.arguments = modelNameDecl
-    ? [modelNameDecl, modelCodegenDecl]
-    : [modelCodegenDecl]
-
   const codegenArgs: string[] = []
   if (modelNameDecl) {
     codegenArgs.push(`"${modelNameDecl.value}"`)

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -209,7 +209,7 @@ describe('transform typescript script setup', () => {
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      defineModel("msg", { type: [String,Number,Array] })
+      defineModel("msg", { type: [String, Number, Array] })
       </script>"
     `)
     expect(
@@ -228,6 +228,15 @@ describe('transform typescript script setup', () => {
     ).toMatchInlineSnapshot(`
       "<script setup>
       defineModel("msg", { type: String, ...{ required: true } })
+      </script>"
+    `)
+    expect(
+      await fixture(
+        `<script setup lang="ts">const model = defineModel <number | undefined>()</script>`,
+      ),
+    ).toMatchInlineSnapshot(`
+      "<script setup>
+      const model = defineModel({ type: Number })
       </script>"
     `)
 

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -232,11 +232,29 @@ describe('transform typescript script setup', () => {
     `)
     expect(
       await fixture(
-        `<script setup lang="ts">const model = defineModel <number | undefined>()</script>`,
+        `<script setup lang="ts">const model = defineModel<number | undefined>()</script>`,
       ),
     ).toMatchInlineSnapshot(`
       "<script setup>
-      const model = defineModel({ type: Number })
+      const model = defineModel({ type: null })
+      </script>"
+    `)
+    expect(
+      await fixture(
+        `<script setup lang="ts">const model = defineModel<boolean | undefined>()</script>`,
+      ),
+    ).toMatchInlineSnapshot(`
+      "<script setup>
+      const model = defineModel({ type: Boolean, skipCheck: true })
+      </script>"
+    `)
+    expect(
+      await fixture(
+        `<script setup lang="ts">const model = defineModel<Function | undefined>()</script>`,
+      ),
+    ).toMatchInlineSnapshot(`
+      "<script setup>
+      const model = defineModel({ type: Function, skipCheck: true })
       </script>"
     `)
 


### PR DESCRIPTION
not sure if there are any edge cases where we need to convert Unknown -> something else