### PR TITLE
fix: limited batch splitter

### DIFF
--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -368,7 +368,9 @@ async function transformJsSnippets(expressions: Expression[], transform: (code: 
 
   try {
     // transform all snippets in a single file
-    const batchInputSplitter = `\nsplitter(${Math.random()});\n`
+    const batchInputSplitter = `\nsplitter(${
+      Math.floor(Math.random() * 900_000_000) + 100_000_000
+    });\n`
     const batchInput = batch
       .map(({ nodes, handler }) => handler.prepare(nodes[0], id))
       .join(batchInputSplitter)


### PR DESCRIPTION
resolve #40

I think a random 9-digit number is enough and it is more stable
