### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-sfc-transformer",
   "type": "module",
   "version": "0.1.17",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.2",
   "description": "Tools for minimal TypeScript transpilation of Vue SFCs",
   "license": "MIT",
   "repository": "nuxt-contrib/vue-sfc-transformer",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,8 +40,8 @@ catalogs:
     vue: 3.5.34
   prod:
     '@babel/parser': ^7.27.0
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-onlyBuiltDependencies:
-  - simple-git-hooks
+
+allowBuilds:
+  "@parcel/watcher": false
+  esbuild: false
+  simple-git-hooks: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,6 +42,6 @@ catalogs:
     '@babel/parser': ^7.27.0
 
 allowBuilds:
-  "@parcel/watcher": false
+  '@parcel/watcher': false
   esbuild: false
   simple-git-hooks: true


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`