### PR TITLE
fix: ignore template directive modifiers

### DIFF
--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -115,6 +115,7 @@ function handleNode(
             ]
           : [node.exp],
         // node.arg,
+        // ..node.modifiers, #273
       ].filter(item => !!item)
       for (const child of nodes) {
         search(child)

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -115,7 +115,6 @@ function handleNode(
             ]
           : [node.exp],
         // node.arg,
-        ...node.modifiers,
       ].filter(item => !!item)
       for (const child of nodes) {
         search(child)

--- a/test/template.test.ts
+++ b/test/template.test.ts
@@ -74,6 +74,9 @@ describe('transform typescript template', () => {
         };
         b()" />"
     `)
+    expect(
+      await fixture(`<input @keydown.delete="handleDelete($event as KeyboardEvent)" />`),
+    ).toEqual(`<input @keydown.delete="handleDelete($event)" />`)
   })
 
   it('v-slot', async () => {


### PR DESCRIPTION
Vue directive modifiers like `.delete` or `.stop` are template metadata, not JavaScript expressions. The fix leaves modifiers untouched while still transpiling the directive’s actual TypeScript expression. 

This prevents syntax errors.