### PR TITLE
fix(rolldown): strip the synthesized `export {}` from transpiled scripts

### DIFF
--- a/src/plugins/rolldown.ts
+++ b/src/plugins/rolldown.ts
@@ -56,7 +56,11 @@ async function transpileScript(code: string, filename = '__sfc.ts'): Promise<str
   if (result.errors.length) {
     throw new AggregateError(result.errors, `[vue-sfc-transformer] failed to transpile script in ${filename}`)
   }
-  return result.code ?? code
+  // When every import in the block is elided as type-only, oxc appends a
+  // synthesized `export {}` to preserve module-ness (tsc emit semantics).
+  // SFC blocks are not module files, and inside `<script setup>` the marker
+  // fails the consumer's `compileScript` - strip it.
+  return (result.code ?? code).replace(/\n?export \{\};?\s*$/, '')
 }
 
 // Transform `.vue` files: strip TS from <script>/<script setup> (lowering

--- a/src/plugins/rolldown.ts
+++ b/src/plugins/rolldown.ts
@@ -56,11 +56,9 @@ async function transpileScript(code: string, filename = '__sfc.ts'): Promise<str
   if (result.errors.length) {
     throw new AggregateError(result.errors, `[vue-sfc-transformer] failed to transpile script in ${filename}`)
   }
-  // When every import in the block is elided as type-only, oxc appends a
-  // synthesized `export {}` to preserve module-ness (tsc emit semantics).
-  // SFC blocks are not module files, and inside `<script setup>` the marker
-  // fails the consumer's `compileScript` - strip it.
-  return (result.code ?? code).replace(/\n?export \{\};?\s*$/, '')
+  // oxc appends `export {}` when every import is elided as type-only; it is
+  // invalid in `<script setup>`, and is emitted before any trailing trivia.
+  return (result.code ?? code).replace(/^export \{\};?[ \t]*\r?\n?/m, '')
 }
 
 // Transform `.vue` files: strip TS from <script>/<script setup> (lowering

--- a/test/rolldown-build.test.ts
+++ b/test/rolldown-build.test.ts
@@ -205,11 +205,6 @@ describe('vueSfcPlugin (end-to-end build)', { timeout: 60_000 }, () => {
     expect(dts).toContain('#button')
   })
 
-  // Bug: when a script block's only module syntax is elided as type-only,
-  // oxc appends a synthesized `export {}` to preserve module-ness (standard
-  // tsc emit semantics). SFC blocks are not module files: inside
-  // `<script setup>` the marker makes every consumer build fail with
-  // `<script setup> cannot contain ES module exports`.
   it('does not emit a synthesized `export {}` when every import is type-only', async () => {
     const typeOnlyRoot = join(root, 'type-only-import')
     await rm(typeOnlyRoot, { force: true, recursive: true })
@@ -221,6 +216,24 @@ describe('vueSfcPlugin (end-to-end build)', { timeout: 60_000 }, () => {
       `const style: CSSProperties = { color: 'red' }`,
       '</script>',
       '<template><div :style="style">styled</div></template>',
+    ].join('\n'))
+    await writeFile(join(typeOnlyRoot, 'src/TypeOnlyTrailingComment.vue'), [
+      '<script setup lang="ts">',
+      `import type { CSSProperties } from 'vue'`,
+      `const style: CSSProperties = { color: 'red' }`,
+      '// trailing comment',
+      '</script>',
+      '<template><div :style="style">styled</div></template>',
+    ].join('\n'))
+    await writeFile(join(typeOnlyRoot, 'src/TypeOnlyScript.vue'), [
+      '<script lang="ts">',
+      `import type { CSSProperties } from 'vue'`,
+      `const style: CSSProperties = { color: 'red' }`,
+      '</script>',
+      '<script setup lang="ts">',
+      `const bound: CSSProperties = style`,
+      '</script>',
+      '<template><div :style="bound">styled</div></template>',
     ].join('\n'))
 
     await build({
@@ -235,6 +248,16 @@ describe('vueSfcPlugin (end-to-end build)', { timeout: 60_000 }, () => {
     const { descriptor } = parse(output, { filename: 'TypeOnly.vue' })
     expect(descriptor.scriptSetup?.content).not.toContain('export {}')
     expect(descriptor.scriptSetup?.content).toContain('const style = { color: "red" }')
+
+    const withComment = await readFile(join(typeOnlyRoot, 'dist/TypeOnlyTrailingComment.vue'), 'utf8')
+    const commented = parse(withComment, { filename: 'TypeOnlyTrailingComment.vue' }).descriptor
+    expect(commented.scriptSetup?.content).not.toContain('export {}')
+    expect(commented.scriptSetup?.content).toContain('// trailing comment')
+
+    const scriptOutput = await readFile(join(typeOnlyRoot, 'dist/TypeOnlyScript.vue'), 'utf8')
+    const script = parse(scriptOutput, { filename: 'TypeOnlyScript.vue' }).descriptor
+    expect(script.script?.content).not.toContain('export {}')
+    expect(script.script?.content).toContain('const style = { color: "red" }')
   })
 
   // Bug: attribute values are serialised with `key="${value}"` without

--- a/test/rolldown-build.test.ts
+++ b/test/rolldown-build.test.ts
@@ -205,6 +205,38 @@ describe('vueSfcPlugin (end-to-end build)', { timeout: 60_000 }, () => {
     expect(dts).toContain('#button')
   })
 
+  // Bug: when a script block's only module syntax is elided as type-only,
+  // oxc appends a synthesized `export {}` to preserve module-ness (standard
+  // tsc emit semantics). SFC blocks are not module files: inside
+  // `<script setup>` the marker makes every consumer build fail with
+  // `<script setup> cannot contain ES module exports`.
+  it('does not emit a synthesized `export {}` when every import is type-only', async () => {
+    const typeOnlyRoot = join(root, 'type-only-import')
+    await rm(typeOnlyRoot, { force: true, recursive: true })
+    await mkdir(join(typeOnlyRoot, 'src'), { recursive: true })
+    await writeFile(join(typeOnlyRoot, 'src/index.ts'), 'export const x = 1\n')
+    await writeFile(join(typeOnlyRoot, 'src/TypeOnly.vue'), [
+      '<script setup lang="ts">',
+      `import type { CSSProperties } from 'vue'`,
+      `const style: CSSProperties = { color: 'red' }`,
+      '</script>',
+      '<template><div :style="style">styled</div></template>',
+    ].join('\n'))
+
+    await build({
+      cwd: typeOnlyRoot,
+      entry: ['src/index.ts'],
+      outDir: 'dist',
+      logLevel: 'silent',
+      plugins: [vueSfcPlugin({ srcDir: 'src', cwd: typeOnlyRoot, cache: false })],
+    })
+
+    const output = await readFile(join(typeOnlyRoot, 'dist/TypeOnly.vue'), 'utf8')
+    const { descriptor } = parse(output, { filename: 'TypeOnly.vue' })
+    expect(descriptor.scriptSetup?.content).not.toContain('export {}')
+    expect(descriptor.scriptSetup?.content).toContain('const style = { color: "red" }')
+  })
+
   // Bug: attribute values are serialised with `key="${value}"` without
   // escaping double quotes in `value`. A single-quoted attribute like
   // `note='says "hi"'` round-trips as `note="says "hi""` - invalid XML,


### PR DESCRIPTION
fixes #304