### PR TITLE
fix(template): transform template with empty ts script block

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,11 +101,11 @@
     "vue-tsc": "catalog:dev"
   },
   "simple-git-hooks": {
-    "pre-commit": "npx lint-staged"
+    "pre-commit": "pnpx lint-staged"
   },
   "lint-staged": {
     "*.{js,ts,mjs,cjs,json,.*rc}": [
-      "npx eslint --fix"
+      "pnpx eslint --fix"
     ]
   }
 }

--- a/src/plugins/rolldown.ts
+++ b/src/plugins/rolldown.ts
@@ -12,6 +12,7 @@ import { parse } from 'vue/compiler-sfc'
 import { emitVueDeclarations } from '../dts/emit'
 import { escapeSfcAttrValue } from '../utils/attrs'
 import { isAbsolute, relative, resolve } from '../utils/path'
+import { getSfcScriptLang } from '../utils/script-lang'
 
 export interface VueSfcPluginOptions {
   // Source directory containing `.vue` files, relative to `cwd`. Also used
@@ -186,7 +187,8 @@ async function transformVueSfc(input: string, filename: string): Promise<Transfo
     return { runtime: input, errors }
   }
 
-  const isTs = [sfc.descriptor.script, sfc.descriptor.scriptSetup].some(b => b?.lang === 'ts')
+  const sfcScriptLang = getSfcScriptLang(input, sfc.descriptor.script, sfc.descriptor.scriptSetup)
+  const isTs = sfcScriptLang === 'ts'
 
   const blocks: Array<{ type: string, attrs: Record<string, string | true>, content: string, offset: number }> = []
 

--- a/src/sfc-transformer.ts
+++ b/src/sfc-transformer.ts
@@ -2,6 +2,7 @@ import type { SFCBlock } from 'vue/compiler-sfc'
 import type { BlockLoader, BlockLoaderContext, LoaderFile, LoadFileContext } from './block-loader/types'
 import { parse } from 'vue/compiler-sfc'
 import { escapeSfcAttrValue } from './utils/attrs'
+import { getSfcScriptLang } from './utils/script-lang'
 import { preTranspileScriptSetup } from './utils/script-setup'
 import { cleanupBreakLine } from './utils/string'
 
@@ -49,9 +50,8 @@ export function defineVueSFCTransformer(options?: VueSFCTransformerOptions): Vue
     }
 
     // we need to remove typescript from template block if the block is typescript
-    const isTs = [sfc.descriptor.script, sfc.descriptor.scriptSetup].some(
-      block => block?.lang === 'ts',
-    )
+    const sfcScriptLang = getSfcScriptLang(input, sfc.descriptor.script, sfc.descriptor.scriptSetup)
+    const isTs = sfcScriptLang === 'ts'
 
     const blocks: SFCBlock[] = [
       ...sfc.descriptor.styles,

--- a/src/utils/script-lang.ts
+++ b/src/utils/script-lang.ts
@@ -1,0 +1,21 @@
+// Empty `<script lang="ts">` blocks are dropped by vue/compiler-sfc when
+// `ignoreEmpty` is on, but their `lang` still applies to the code generated
+// from the template. Mirrors `emptyScriptLangRE` from @vitejs/plugin-vue.
+const emptyScriptTsLangRE = /<script[^>]*\slang\s*=\s*["']?ts\b[^>]*?(?:\/>|>\s*<\/script\s*>)/
+
+/**
+ * The script `lang` that applies to the SFC as a whole: `'ts'` when any
+ * `<script>` / `<script setup>` block has `lang="ts"` — including empty
+ * blocks the SFC parser drops — `undefined` otherwise.
+ */
+export function getSfcScriptLang(
+  raw: string,
+  ...blocks: Array<{ lang?: string } | null | undefined>
+): 'ts' | undefined {
+  for (const block of blocks) {
+    if (block?.lang === 'ts') {
+      return 'ts'
+    }
+  }
+  return emptyScriptTsLangRE.test(raw) ? 'ts' : undefined
+}

--- a/test/mkdist.test.ts
+++ b/test/mkdist.test.ts
@@ -243,11 +243,10 @@ describe('transform typescript script setup', () => {
     const output = await fixture(src)
     expect(output).not.toContain('as string')
     expect(output).toMatchInlineSnapshot(`
-      "<script lang="ts"></script>
-
-      <template>
-        <div>{{ (msg as string) }}</div>
-      </template>"
+      "<template>
+        <div>{{ msg }}</div>
+      </template>
+      "
     `)
   })
 

--- a/test/mkdist.test.ts
+++ b/test/mkdist.test.ts
@@ -233,6 +233,24 @@ describe('transform typescript script setup', () => {
     `)
   })
 
+  it('applies an empty ts script lang to the template', async () => {
+    const src = `<script lang="ts"></script>
+
+<template>
+  <div>{{ (msg as string) }}</div>
+</template>`
+
+    const output = await fixture(src)
+    expect(output).not.toContain('as string')
+    expect(output).toMatchInlineSnapshot(`
+      "<script lang="ts"></script>
+
+      <template>
+        <div>{{ (msg as string) }}</div>
+      </template>"
+    `)
+  })
+
   it('generates declaration', { timeout: 50_000 }, async () => {
     const src = `
       <template>


### PR DESCRIPTION
Sfc with empty script block won't be transformed before, the PR fix it.

```vue
<script lang="ts"></script>

<template>
  <div>{{ (msg as string) }}</div>
</template>
```

- [x] I know the `lang` may also be `jsx` or `tsx`, but fix `tsx` support is not in this PR's range.